### PR TITLE
CakePHP's default primary key is just ``id''

### DIFF
--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -63,7 +63,7 @@ class UsersController extends AppController{
       $this->loadModel('Comments');
       $comment = $this->Comments
         ->find()
-        ->where(['Comment_ID >=' => '0'])
+        ->where(['id >=' => '0'])
         ->toArray();
       $this->set('comments', $comment);
 


### PR DESCRIPTION
When I set up the database using Migrations, it just automatically creates an `id` column and sets it as the primary key.  Therefore, `Comment_ID` doesn't exist in the new schema.