### PR TITLE
Updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@
 /logs/*
 /tmp/*
 /vendor/*
-/config/Migrations/schema-dump-default.lock
+/config/Migrations/schema-dump-*.lock
 
 ##################
 # Composer files #


### PR DESCRIPTION
I found out that each of the connections, when you utilize them, create a 'schema-dump' lock file.  This is their naming convention.